### PR TITLE
[Fix] 修复配偶节点和孩子节点位置展示不正确的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Component data to support those field：
 
 ### Example 1
 
-![](C:\Users\Spring-_-Bear\Desktop\样例1.png)
+![样例1](https://user-images.githubusercontent.com/104678885/220013648-1048a79d-ec18-4cde-87d6-367eaffb1931.png)
+
 
 ```js
   {
@@ -106,7 +107,8 @@ Component data to support those field：
 
 ### Example 2
 
-![](C:\Users\Spring-_-Bear\Desktop\红楼梦.png)
+![红楼梦](https://user-images.githubusercontent.com/104678885/220013679-1ca40c62-6123-4317-9e8b-3487d774c55b.png)
+
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ Component data to support those field：
 - extend[Boolean] show/hide node`s children, default True
 ```
 
-Example：
+## Examples
+
+### Example 1
+
+![](C:\Users\Spring-_-Bear\Desktop\样例1.png)
 
 ```js
   {
@@ -98,6 +102,110 @@ Example：
       }
     ]
   }
+```
+
+### Example 2
+
+![](C:\Users\Spring-_-Bear\Desktop\红楼梦.png)
+
+```json
+{
+    name: '贾太公',
+    children: [
+        {
+            name: '贾演',
+            children: [
+                {
+                    name: '贾代化',
+                    children: [
+                        {name: '贾敷'},
+                        {
+                            name: '贾敬',
+                            children: [
+                                {
+                                    name: '贾珍',
+                                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                                    children: [
+                                        {
+                                            name: '贾蓉',
+                                            mate: [
+                                                {name: '秦可卿'}
+                                            ]
+                                        }
+                                    ],
+                                    mate: [
+                                        {name: '尤氏'},
+                                    ],
+                                },
+                                {name: '贾惜春'},
+                            ]
+                        },
+                    ]
+                },
+            ]
+        },
+        {
+            name: '贾源',
+            children: [
+                {
+                    name: '贾代善',
+                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                    mate: [
+                        {name: '史太君'}
+                    ],
+                    children: [
+                        {
+                            name: '贾赦',
+                            children: [
+                                {
+                                    name: '贾琏',
+                                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                                    mate: [
+                                        {name: '王熙凤'},
+                                        {name: '尤二姐'}
+                                    ],
+                                    children: [
+                                        {name: '巧姐'},
+                                    ]
+                                },
+                                {name: '贾迎春'},
+                            ]
+                        },
+                        {
+                            name: '贾政',
+                            image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                            children: [
+                                {
+                                    name: '贾宝玉',
+                                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                                    mate: [
+                                        {name: '薛宝钗'}
+                                    ],
+                                },
+                                {name: '贾元春'},
+                                {name: '贾珠'},
+                                {name: '贾探春'},
+                                {name: '贾环'},
+                            ],
+                            mate: [
+                                {name: '王夫人',},
+                                {name: '赵姨娘',},
+                            ],
+                        },
+                        {
+                            name: '贾敏',
+                            image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                            children: [
+                                {name: '林黛玉'},
+                            ],
+                            mate: [{name: '林如海',}],
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
 ```
 
 ## Event

--- a/README_CN.md
+++ b/README_CN.md
@@ -58,7 +58,11 @@ export default {
 - extend[Boolean] 展开/收起节点后代，默认展开
 ```
 
-示例：
+## 示例
+
+### 样例 1
+
+![](C:\Users\Spring-_-Bear\Desktop\样例1.png)
 
 ```js
   {
@@ -98,6 +102,110 @@ export default {
       }
     ]
   }
+```
+
+### 样例 2
+
+![](C:\Users\Spring-_-Bear\Desktop\红楼梦.png)
+
+```json
+{
+    name: '贾太公',
+    children: [
+        {
+            name: '贾演',
+            children: [
+                {
+                    name: '贾代化',
+                    children: [
+                        {name: '贾敷'},
+                        {
+                            name: '贾敬',
+                            children: [
+                                {
+                                    name: '贾珍',
+                                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                                    children: [
+                                        {
+                                            name: '贾蓉',
+                                            mate: [
+                                                {name: '秦可卿'}
+                                            ]
+                                        }
+                                    ],
+                                    mate: [
+                                        {name: '尤氏'},
+                                    ],
+                                },
+                                {name: '贾惜春'},
+                            ]
+                        },
+                    ]
+                },
+            ]
+        },
+        {
+            name: '贾源',
+            children: [
+                {
+                    name: '贾代善',
+                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                    mate: [
+                        {name: '史太君'}
+                    ],
+                    children: [
+                        {
+                            name: '贾赦',
+                            children: [
+                                {
+                                    name: '贾琏',
+                                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                                    mate: [
+                                        {name: '王熙凤'},
+                                        {name: '尤二姐'}
+                                    ],
+                                    children: [
+                                        {name: '巧姐'},
+                                    ]
+                                },
+                                {name: '贾迎春'},
+                            ]
+                        },
+                        {
+                            name: '贾政',
+                            image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                            children: [
+                                {
+                                    name: '贾宝玉',
+                                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                                    mate: [
+                                        {name: '薛宝钗'}
+                                    ],
+                                },
+                                {name: '贾元春'},
+                                {name: '贾珠'},
+                                {name: '贾探春'},
+                                {name: '贾环'},
+                            ],
+                            mate: [
+                                {name: '王夫人',},
+                                {name: '赵姨娘',},
+                            ],
+                        },
+                        {
+                            name: '贾敏',
+                            image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                            children: [
+                                {name: '林黛玉'},
+                            ],
+                            mate: [{name: '林如海',}],
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
 ```
 
 ## 事件

--- a/README_CN.md
+++ b/README_CN.md
@@ -62,7 +62,7 @@ export default {
 
 ### 样例 1
 
-![](C:\Users\Spring-_-Bear\Desktop\样例1.png)
+![样例1](https://user-images.githubusercontent.com/104678885/220013648-1048a79d-ec18-4cde-87d6-367eaffb1931.png)
 
 ```js
   {
@@ -106,7 +106,7 @@ export default {
 
 ### 样例 2
 
-![](C:\Users\Spring-_-Bear\Desktop\红楼梦.png)
+![红楼梦](https://user-images.githubusercontent.com/104678885/220013679-1ca40c62-6123-4317-9e8b-3487d774c55b.png)
 
 ```json
 {

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,13 +4,13 @@
       切换为横向
       <input type="checkbox" v-model="landscape" value="1">
     </label>
-    <TreeChart :json="data" :class="{landscape: landscape.length}" @click-node="clickNode" />
+    <TreeChart :json="data" :class="{landscape: landscape.length}" @click-node="clickNode"/>
     <footer class="foot">
-        <p>© 2018 - 3018 Author
-            <a href="https://refined-x.com/" target="_blank">雅X共赏</a> 
-            Github 
-            <a href="https://github.com/tower1229/Vue-Tree-Chart" target="_blank">Vue-Tree-Chart</a>
-        </p>
+      <p>© 2018 - 3018 Author
+        <a href="https://refined-x.com/" target="_blank">雅X共赏</a>
+        Github
+        <a href="https://github.com/tower1229/Vue-Tree-Chart" target="_blank">Vue-Tree-Chart</a>
+      </p>
     </footer>
   </div>
 </template>
@@ -27,44 +27,141 @@ export default {
     return {
       landscape: [],
       data: {
-        name: 'root',
-        image_url: "https://static.refined-x.com/static/avatar.jpg",
-        class: ["rootNode"],
+        name: '贾太公',
         children: [
           {
-            name: 'children1',
-            image_url: "https://static.refined-x.com/static/avatar.jpg"
-          },
-          {
-            name: 'children2',
-            image_url: "https://static.refined-x.com/static/avatar.jpg",
-            mate: [
-              {
-                name: 'mate',
-                image_url: "https://static.refined-x.com/static/avatar.jpg"
-              }
-            ],
+            name: '贾演',
             children: [
               {
-                name: 'grandchild',
-                image_url: "https://static.refined-x.com/static/avatar.jpg"
+                name: '贾代化',
+                children: [
+                  {name: '贾敷'},
+                  {
+                    name: '贾敬',
+                    children: [
+                      {
+                        name: '贾珍',
+                        image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                        children: [
+                          {
+                            name: '贾蓉',
+                            mate: [
+                              {name: '秦可卿'}
+                            ]
+                          }
+                        ],
+                        mate: [
+                          {name: '尤氏'},
+                        ],
+                      },
+                      {name: '贾惜春'},
+                    ]
+                  },
+                ]
               },
+            ]
+          },
+          {
+            name: '贾源',
+            children: [
               {
-                name: 'grandchild2',
-                image_url: "https://static.refined-x.com/static/avatar.jpg"
-              },
-              {
-                name: 'grandchild3',
-                image_url: "https://static.refined-x.com/static/avatar.jpg"
+                name: '贾代善',
+                image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                mate: [
+                  {name: '史太君'}
+                ],
+                children: [
+                  {
+                    name: '贾赦',
+                    children: [
+                      {
+                        name: '贾琏',
+                        image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                        mate: [
+                          {name: '王熙凤'},
+                          {name: '尤二姐'}
+                        ],
+                        children: [
+                          {name: '巧姐'},
+                        ]
+                      },
+                      {name: '贾迎春'},
+                    ]
+                  },
+                  {
+                    name: '贾政',
+                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                    children: [
+                      {
+                        name: '贾宝玉',
+                        image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                        mate: [
+                          {name: '薛宝钗'}
+                        ],
+                      },
+                      {name: '贾元春'},
+                      {name: '贾珠'},
+                      {name: '贾探春'},
+                      {name: '贾环'},
+                    ],
+                    mate: [
+                      {name: '王夫人',},
+                      {name: '赵姨娘',},
+                    ],
+                  },
+                  {
+                    name: '贾敏',
+                    image_url: "https://img01.yzcdn.cn/vant/cat.jpeg",
+                    children: [
+                      {name: '林黛玉'},
+                    ],
+                    mate: [{name: '林如海',}],
+                  }
+                ]
               }
             ]
           }
         ]
-      }
+      },
+      // data: {
+      //   name: 'root',
+      //   image_url: "https://static.refined-x.com/static/avatar.jpg",
+      //   class: ["rootNode"],
+      //   children: [
+      //     {
+      //       name: 'children1',
+      //       image_url: "https://static.refined-x.com/static/avatar.jpg"
+      //     },
+      //     {
+      //       name: 'children2',
+      //       image_url: "https://static.refined-x.com/static/avatar.jpg",
+      //       mate: [
+      //         {
+      //           name: 'mate',
+      //           image_url: "https://static.refined-x.com/static/avatar.jpg"
+      //         }
+      //       ],
+      //       children: [
+      //         {
+      //           name: 'grandchild',
+      //           image_url: "https://static.refined-x.com/static/avatar.jpg"
+      //         },
+      //         {
+      //           name: 'grandchild2',
+      //           image_url: "https://static.refined-x.com/static/avatar.jpg"
+      //         },
+      //         {
+      //           name: 'grandchild3',
+      //           image_url: "https://static.refined-x.com/static/avatar.jpg"
+      //         }
+      //       ]
+      //     }
+      //   ]
+      // }
     }
   },
   methods: {
-    clickNode: function(node){
+    clickNode: function (node) {
       // eslint-disable-next-line
       console.log(node)
     }
@@ -81,23 +178,35 @@ export default {
   color: #2c3e50;
   margin-top: 60px;
 }
-#app .avat{border-radius: 2em;border-width:2px;}
-#app .name{font-weight:700;}
-#app .rootNode .name{
+
+#app .avat {
+  border-radius: 2em;
+  border-width: 2px;
+}
+
+#app .name {
+  font-weight: 700;
+}
+
+#app .rootNode .name {
   color: red;
 }
 
 .foot {
-    position: fixed;
-    left: 0;
-    bottom: 0;
-    width: 100%;
-    background: #333;
-    padding: 24px;
-    overflow: hidden;
-    color: #999;
-    font-size: 14px;
-    text-align: center;
+  position: fixed;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  background: #333;
+  padding: 24px;
+  overflow: hidden;
+  color: #999;
+  font-size: 14px;
+  text-align: center;
 }
-.foot a{color:#fff;margin:0 .5em}
+
+.foot a {
+  color: #fff;
+  margin: 0 .5em
+}
 </style>

--- a/src/components/TreeChart.vue
+++ b/src/components/TreeChart.vue
@@ -1,46 +1,48 @@
 <template>
-    <table v-if="treeData.name">
-      <tr>
-        <td :colspan="Array.isArray(treeData.children) ? treeData.children.length * 2 : 1" 
+  <table v-if="treeData.name" class="single">
+    <tr>
+      <td :colspan="Array.isArray(treeData.children) ? treeData.children.length * 2 : 1"
           :class="{parentLevel: Array.isArray(treeData.children) && treeData.children.length, extend: Array.isArray(treeData.children) && treeData.children.length && treeData.extend}"
-        >
-          <div :class="{node: true, hasMate: treeData.mate}">
-            <div class="person" 
-              :class="Array.isArray(treeData.class) ? treeData.class : []"
-              @click="$emit('click-node', treeData)"
+      >
+        <div :class="{node: true, hasMate: treeData.mate}">
+          <div class="person"
+               :class="Array.isArray(treeData.class) ? treeData.class : []"
+               @click="$emit('click-node', treeData)"
+          >
+            <div class="avat">
+              <img :src="treeData.image_url"/>
+            </div>
+            <div class="name">{{ treeData.name }}</div>
+          </div>
+          <template v-if="Array.isArray(treeData.mate) && treeData.mate.length">
+            <div class="person" v-for="(mate, mateIndex) in treeData.mate" :key="treeData.name+mateIndex"
+                 :class="Array.isArray(mate.class) ? mate.class : []"
+                 @click="$emit('click-node', mate)"
             >
               <div class="avat">
-                <img :src="treeData.image_url" />
+                <img :src="mate.image_url"/>
               </div>
-              <div class="name">{{treeData.name}}</div>
+              <div class="name">{{ mate.name }}</div>
             </div>
-            <template v-if="Array.isArray(treeData.mate) && treeData.mate.length">
-              <div class="person" v-for="(mate, mateIndex) in treeData.mate" :key="treeData.name+mateIndex"
-                :class="Array.isArray(mate.class) ? mate.class : []"
-                @click="$emit('click-node', mate)"
-              >
-                <div class="avat">
-                  <img :src="mate.image_url" />
-                </div>
-                <div class="name">{{mate.name}}</div>
-              </div>
-            </template>
-          </div>
-          <div class="extend_handle" v-if="Array.isArray(treeData.children) && treeData.children.length" @click="toggleExtend(treeData)"></div>
-        </td>
-      </tr>
-      <tr v-if="Array.isArray(treeData.children) && treeData.children.length && treeData.extend">
-        <td v-for="(children, index) in treeData.children" :key="index" colspan="2" class="childLevel">
-          <TreeChart :json="children" @click-node="$emit('click-node', $event)"/>
-        </td>
-      </tr>
-    </table>
+          </template>
+        </div>
+        <div class="extend_handle" v-if="Array.isArray(treeData.children) && treeData.children.length"
+             @click="toggleExtend(treeData)"></div>
+      </td>
+    </tr>
+    <tr v-if="Array.isArray(treeData.children) && treeData.children.length && treeData.extend">
+      <td v-for="(children, index) in treeData.children" :key="index" colspan="2" class="childLevel">
+        <TreeChart :json="children" @click-node="$emit('click-node', $event)" :single="treeData.children.length === 1"/>
+      </td>
+    </tr>
+  </table>
 </template>
 
 <script>
 export default {
   name: "TreeChart",
-  props: ["json"],
+  // Fix: single 用于解决一对夫妇仅拥有一个孩子时孩子位置不正确的问题
+  props: ["json", 'single'],
   data() {
     return {
       treeData: {}
@@ -48,17 +50,17 @@ export default {
   },
   watch: {
     json: {
-      handler: function(Props){
-        let extendKey = function(jsonData){
-          jsonData.extend = (jsonData.extend===void 0 ? true: !!jsonData.extend);
-          if(Array.isArray(jsonData.children)){
+      handler: function (Props) {
+        let extendKey = function (jsonData) {
+          jsonData.extend = (jsonData.extend === void 0 ? true : !!jsonData.extend);
+          if (Array.isArray(jsonData.children)) {
             jsonData.children.forEach(c => {
               extendKey(c)
             })
           }
           return jsonData;
         }
-        if(Props){
+        if (Props) {
           this.treeData = extendKey(Props);
         }
       },
@@ -66,7 +68,7 @@ export default {
     }
   },
   methods: {
-    toggleExtend: function(treeData){
+    toggleExtend: function (treeData) {
       treeData.extend = !treeData.extend;
       this.$forceUpdate();
     }
@@ -75,37 +77,210 @@ export default {
 </script>
 
 <style scoped>
-table{border-collapse: separate!important;border-spacing: 0!important;}
-td{position: relative; vertical-align: top;padding:0 0 50px 0;text-align: center; }
+table {
+  border-collapse: separate !important;
+  border-spacing: 0 !important;
+}
 
-.extend_handle{position: absolute;left:50%;bottom:30px; width:10px;height: 10px;padding:10px;transform: translate3d(-15px,0,0);cursor: pointer;}
-.extend_handle:before{content:""; display: block; width:100%;height: 100%;box-sizing: border-box; border:2px solid;border-color:#ccc #ccc transparent transparent;
-transform: rotateZ(135deg);transform-origin: 50% 50% 0;transition: transform ease 300ms;}
-.extend_handle:hover:before{border-color:#333 #333 transparent transparent;}
-.extend .extend_handle:before{transform: rotateZ(-45deg);}
+td {
+  position: relative;
+  vertical-align: top;
+  padding: 0 0 50px 0;
+  text-align: center;
+}
 
-.extend::after{content: "";position: absolute;left:50%;bottom:15px;height:15px;border-left:2px solid #ccc;transform: translate3d(-1px,0,0)}
-.childLevel::before{content: "";position: absolute;left:50%;bottom:100%;height:15px;border-left:2px solid #ccc;transform: translate3d(-1px,0,0)}
-.childLevel::after{content: "";position: absolute;left:0;right:0;top:-15px;border-top:2px solid #ccc;}
-.childLevel:first-child:before, .childLevel:last-child:before{display: none;}
-.childLevel:first-child:after{left:50%;height:15px; border:2px solid;border-color:#ccc transparent transparent #ccc;border-radius: 6px 0 0 0;transform: translate3d(1px,0,0)}
-.childLevel:last-child:after{right:50%;height:15px; border:2px solid;border-color:#ccc #ccc transparent transparent;border-radius: 0 6px 0 0;transform: translate3d(-1px,0,0)}
-.childLevel:first-child.childLevel:last-child::after{left:auto;border-radius: 0;border-color:transparent #ccc transparent transparent;transform: translate3d(1px,0,0)}
+.extend_handle {
+  position: absolute;
+  left: 50%;
+  bottom: 30px;
+  width: 10px;
+  height: 10px;
+  padding: 10px;
+  transform: translate3d(-15px, 0, 0);
+  cursor: pointer;
+}
 
-.node{position: relative; display: inline-block;margin: 0 1em;box-sizing: border-box; text-align: center;}
-.node .person{position: relative; display: inline-block;z-index: 2;width:6em; overflow: hidden;}
-.node .person .avat{display: block;width:4em;height: 4em;margin:auto;overflow:hidden; background:#fff;border:1px solid #ccc;box-sizing: border-box;}
-.node .person .avat img{width:100%;height: 100%;}
-.node .person .name{height:2em;line-height: 2em;overflow: hidden;width:100%;}
-.node.hasMate::after{content: "";position: absolute;left:2em;right:2em;top:2em;border-top:2px solid #ccc;z-index: 1;}
+.extend_handle:before {
+  content: "";
+  display: block;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  border: 2px solid;
+  border-color: #ccc #ccc transparent transparent;
+  transform: rotateZ(135deg);
+  transform-origin: 50% 50% 0;
+  transition: transform ease 300ms;
+}
+
+.extend_handle:hover:before {
+  border-color: #333 #333 transparent transparent;
+}
+
+.extend .extend_handle:before {
+  transform: rotateZ(-45deg);
+}
+
+.extend::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 15px;
+  height: 15px;
+  border-left: 2px solid #ccc;
+  transform: translate3d(-1px, 0, 0)
+}
+
+.childLevel::before {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 100%;
+  height: 15px;
+  border-left: 2px solid #ccc;
+  transform: translate3d(-1px, 0, 0)
+}
+
+.childLevel::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: -15px;
+  border-top: 2px solid #ccc;
+}
+
+.childLevel:first-child:before, .childLevel:last-child:before {
+  display: none;
+}
+
+.childLevel:first-child:after {
+  left: 50%;
+  height: 15px;
+  border: 2px solid;
+  border-color: #ccc transparent transparent #ccc;
+  border-radius: 6px 0 0 0;
+  transform: translate3d(1px, 0, 0)
+}
+
+.childLevel:last-child:after {
+  right: 50%;
+  height: 15px;
+  border: 2px solid;
+  border-color: #ccc #ccc transparent transparent;
+  border-radius: 0 6px 0 0;
+  transform: translate3d(-1px, 0, 0)
+}
+
+.childLevel:first-child.childLevel:last-child::after {
+  left: auto;
+  border-radius: 0;
+  border-color: transparent #ccc transparent transparent;
+  transform: translate3d(1px, 0, 0)
+}
+
+.node {
+  position: relative;
+  display: inline-block;
+  margin: 0 1em;
+  box-sizing: border-box;
+  text-align: center;
+  /* Fix: white-space: nowrap; 用于解决页面缩放时配偶排列到丈夫下方的问题*/
+  white-space: nowrap;
+}
+
+.node .person {
+  position: relative;
+  display: inline-block;
+  z-index: 2;
+  width: 6em;
+  overflow: hidden;
+  white-space: normal;
+}
+
+.node .person .avat {
+  display: block;
+  width: 4em;
+  height: 4em;
+  margin: auto;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid #ccc;
+  box-sizing: border-box;
+}
+
+.node .person .avat img {
+  width: 100%;
+  height: 100%;
+}
+
+.node .person .name {
+  height: 2em;
+  line-height: 2em;
+  overflow: hidden;
+  width: 100%;
+}
+
+.node.hasMate::after {
+  content: "";
+  position: absolute;
+  left: 2em;
+  right: 2em;
+  top: 2em;
+  border-top: 2px solid #ccc;
+  z-index: 1;
+}
+
 /* 横板 */
-.landscape{transform:translate(-100%,0) rotate(-90deg);transform-origin: 100% 0;}
-.landscape .node{text-align: left;height: 8em;width:8em;}
-.landscape .person{position: relative; transform: rotate(90deg);padding-left: 4.5em;height: 4em;top:4em;left: -1em;}
-.landscape .person .avat{position: absolute;left: 0;}
-.landscape .person .name{height: 4em; line-height: 4em;}
-.landscape .hasMate{position: relative;}
-.landscape .hasMate .person{position: absolute; }
-.landscape .hasMate .person:first-child{left:auto; right:-4em;}
-.landscape .hasMate .person:last-child{left: -4em;margin-left:0;}
+.landscape {
+  transform: translate(-100%, 0) rotate(-90deg);
+  transform-origin: 100% 0;
+}
+
+.landscape .node {
+  text-align: left;
+  height: 8em;
+  width: 8em;
+}
+
+.landscape .person {
+  position: relative;
+  transform: rotate(90deg);
+  padding-left: 4.5em;
+  height: 4em;
+  top: 4em;
+  left: -1em;
+}
+
+.landscape .person .avat {
+  position: absolute;
+  left: 0;
+}
+
+.landscape .person .name {
+  height: 4em;
+  line-height: 4em;
+}
+
+.landscape .hasMate {
+  position: relative;
+}
+
+.landscape .hasMate .person {
+  position: absolute;
+}
+
+.landscape .hasMate .person:first-child {
+  left: auto;
+  right: -4em;
+}
+
+.landscape .hasMate .person:last-child {
+  left: -4em;
+  margin-left: 0;
+}
+
+.single {
+  margin: auto;
+}
 </style>


### PR DESCRIPTION
1.  修复页面缩放时配偶节点被 ”挤“ 到丈夫节点下方的问题，正常情况下所有配偶节点应排列到丈夫节点右方；

![](https://user-images.githubusercontent.com/104678885/219957625-e69bd1e9-29bb-4ba2-a4fb-bf0b7becb539.png)

2.  修复一对夫妇下仅有一个孩子时孩子位置展示靠左的问题，正常情况下孩子节点应位于丈夫和妻子的正下方；

![https://user-images.githubusercontent.com/104678885/219957816-9334ceb9-1cd2-4406-989d-60417922a4d3.png](https://user-images.githubusercontent.com/104678885/219957816-9334ceb9-1cd2-4406-989d-60417922a4d3.png)

3  更新 README 文件，添加样例图片和样例数据。



![https://user-images.githubusercontent.com/104678885/220013679-1ca40c62-6123-4317-9e8b-3487d774c55b.png](https://user-images.githubusercontent.com/104678885/220013679-1ca40c62-6123-4317-9e8b-3487d774c55b.png)